### PR TITLE
Require cl-lib at compile time

### DIFF
--- a/flycheck-status-emoji.el
+++ b/flycheck-status-emoji.el
@@ -47,10 +47,11 @@
 ;;  dependencies
 ;;
 
-(require 'cl-lib)
 (require 'flycheck)
 
-(eval-when-compile (require 'let-alist))
+(eval-when-compile
+  (require 'cl-lib)
+  (require 'let-alist))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
`cl-ecase` (macro) is not required at runtime. See:

[CommonLispForEmacs](https://www.emacswiki.org/emacs/CommonLispForEmacs)